### PR TITLE
sync with upstream: openmpi, module defaults

### DIFF
--- a/defaults/modules.yaml
+++ b/defaults/modules.yaml
@@ -1,4 +1,9 @@
 modules:
+  prefix_inspections:
+    bin:
+      - PATH
+    lib:
+      - LIBRARY_PATH
   enable::
     - lmod
   lmod:

--- a/defaults/modules.yaml
+++ b/defaults/modules.yaml
@@ -4,6 +4,8 @@ modules:
       - PATH
     lib:
       - LIBRARY_PATH
+    include:
+      - CPATH
   enable::
     - lmod
   lmod:

--- a/defaults/packages.yaml
+++ b/defaults/packages.yaml
@@ -17,7 +17,7 @@ packages:
   mpich:
     version: [3.3.2]
   openmpi:
-    variants: +pmi schedulers=slurm
+    variants: +pmi +legacylaunchers schedulers=slurm fabrics=ucx,ofi
     version: [4.0.5]
   proj:
     version: [7.2.1]

--- a/defaults/packages.yaml
+++ b/defaults/packages.yaml
@@ -17,6 +17,7 @@ packages:
   mpich:
     version: [3.3.2]
   openmpi:
+    variants: +pmi schedulers=slurm
     version: [4.0.5]
   proj:
     version: [7.2.1]

--- a/install.sh
+++ b/install.sh
@@ -107,3 +107,12 @@ done
 
 
 #################END_OF_SOFTWARE_INSTALLS####################################
+
+
+#have spack regenerate module files:
+
+spack module lmod refresh --delete-tree -y
+
+
+exit 0
+

--- a/install.sh
+++ b/install.sh
@@ -59,9 +59,10 @@ cp defaults/packages.yaml spack/etc/spack/defaults/packages.yaml
 #source the spack environment
 source spack/share/spack/setup-env.sh
 
-#install compilers
-spack install -j${CORECOUNT} gcc@10.1.0%gcc@4.8.5 target=${ARCH}
-spack install -j${CORECOUNT} intel-oneapi-compilers@2021.2.0%gcc@4.8.5 target=${ARCH}
+#install compilers 
+#fix was added due to zen2 not having optimizations w/ 4.8.5 compiler
+spack install -j${CORECOUNT} gcc@10.1.0%gcc@4.8.5 target=x86_64
+spack install -j${CORECOUNT} intel-oneapi-compilers@2021.2.0%gcc@4.8.5 target=x86_64
 
 #now add the compilers - gcc
 spack compiler find `spack location --install-dir gcc@10.1.0`


### PR DESCRIPTION
changes include variations on openmpi@4. and adding CPATH to modules.